### PR TITLE
prepare 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.1.1] - 2018-08-29
+
+Incorporates the fix from 1.0.6 that was not included in 1.1.0.
+
 ## [1.1.0] - 2018-08-22
 
 ### Added

--- a/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
+++ b/src/LaunchDarkly.Common.StrongName/LaunchDarkly.Common.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
+++ b/src/LaunchDarkly.Common/LaunchDarkly.Common.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-client-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
This is simply version 1.1.0 plus the fix from 1.0.6 (since 1.1.0 was released prior to that patch).