### PR TITLE
prepare 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 For full release notes for the projects that depend on this project, see their respective changelogs. This file describes changes only to the common code. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.4.0] - 2019-07-31
+### Added:
+- `IBaseConfiguration.EventCapacity` and `IBaseConfiguration.EventFlushInterval`.
+- `UserBuilder.Key` setter.
+
+### Deprecated:
+- `IBaseConfiguration.SamplingInterval`.
+- `IBaseConfiguration.EventQueueCapacity` (now a synonym for `EventCapacity`).
+- `IBaseConfiguration.EventQueueFrequency` (now a synonym for `EventFlushInterval`).
+
 ## [2.3.0] - 2019-07-23
 ### Deprecated:
 - `User` constructors.

--- a/src/LaunchDarkly.CommonSdk.StrongName/LaunchDarkly.CommonSdk.StrongName.csproj
+++ b/src/LaunchDarkly.CommonSdk.StrongName/LaunchDarkly.CommonSdk.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta2</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-sdk-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.CommonSdk.StrongName/LaunchDarkly.CommonSdk.StrongName.csproj
+++ b/src/LaunchDarkly.CommonSdk.StrongName/LaunchDarkly.CommonSdk.StrongName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>3.0.0-beta2</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-sdk-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.CommonSdk/IBaseConfiguration.cs
+++ b/src/LaunchDarkly.CommonSdk/IBaseConfiguration.cs
@@ -47,24 +47,45 @@ namespace LaunchDarkly.Common
         TimeSpan ReconnectTime { get; }
         
         /// <summary>
-        /// The capacity of the events buffer. The client buffers up to this many events in
-        /// memory before flushing. If the capacity is exceeded before the buffer is flushed,
-        /// events will be discarded. Increasing the capacity means that events are less likely
-        /// to be discarded, at the cost of consuming more memory.
+        /// The capacity of the events buffer.
         /// </summary>
+        /// <remarks>
+        /// The client buffers up to this many events in memory before flushing. If the capacity is
+        /// exceeded before the buffer is flushed, events will be discarded. Increasing the capacity means
+        /// that events are less likely to be discarded, at the cost of consuming more memory.
+        /// </remarks>
+        int EventCapacity { get; }
+
+        /// <summary>
+        /// Deprecated name for <see cref="EventCapacity"/>.
+        /// </summary>
+        [Obsolete("Use EventCapacity")]
         int EventQueueCapacity { get; }
 
         /// <summary>
-        /// The time between flushes of the event buffer. Decreasing the flush interval means
-        /// that the event buffer is less likely to reach capacity. The default value is 5 seconds.
+        /// The time between flushes of the event buffer.
         /// </summary>
+        /// <remarks>
+        /// Decreasing the flush interval means that the event buffer is less likely to reach
+        /// capacity. The default value is 5 seconds.
+        /// </remarks>
+        TimeSpan EventFlushInterval { get; }
+
+        /// <summary>
+        /// Deprecated name for <see cref="EventFlushInterval"/>.
+        /// </summary>
+        [Obsolete("Use EventFlushInterval")]
         TimeSpan EventQueueFrequency { get; }
         
         /// <summary>
-        /// Enables event sampling if non-zero. When set to the default of zero, all analytics events are
-        /// sent back to LaunchDarkly. When greater than zero, there is a 1 in <c>EventSamplingInterval</c>
-        /// chance that events will be sent (example: if the interval is 20, on average 5% of events will be sent).
+        /// Deprecated. Enables event sampling if non-zero.
         /// </summary>
+        /// <remarks>
+        /// When set to the default of zero, all analytics events are sent back to LaunchDarkly. When greater
+        /// than zero, there is a 1 in <c>EventSamplingInterval</c> chance that events will be sent (example:
+        /// if the interval is 20, on average 5% of events will be sent).
+        /// </remarks>
+        [Obsolete("This feature will be removed in a future version of the SDK")]
         int EventSamplingInterval { get; }
 
         /// <summary>

--- a/src/LaunchDarkly.CommonSdk/LaunchDarkly.CommonSdk.csproj
+++ b/src/LaunchDarkly.CommonSdk/LaunchDarkly.CommonSdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.0.0-beta2</Version>
+    <Version>2.4.0</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-sdk-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.CommonSdk/LaunchDarkly.CommonSdk.csproj
+++ b/src/LaunchDarkly.CommonSdk/LaunchDarkly.CommonSdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.3.0</Version>
+    <Version>3.0.0-beta2</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/dotnet-sdk-common/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.CommonSdk/UserBuilder.cs
+++ b/src/LaunchDarkly.CommonSdk/UserBuilder.cs
@@ -28,6 +28,13 @@ namespace LaunchDarkly.Client
         User Build();
 
         /// <summary>
+        /// Sets the unique key for a user.
+        /// </summary>
+        /// <param name="key">the key</param>
+        /// <returns>the same builder</returns>
+        IUserBuilder Key(string key);
+
+        /// <summary>
         /// Sets the secondary key for a user.
         /// </summary>
         /// <remarks>
@@ -196,7 +203,7 @@ namespace LaunchDarkly.Client
 
     internal class UserBuilder : IUserBuilder
     {
-        private readonly string _key;
+        private string _key;
         private string _secondaryKey;
         private string _ipAddress;
         private string _country;
@@ -226,9 +233,9 @@ namespace LaunchDarkly.Client
             _avatar = fromUser.Avatar;
             _email = fromUser.Email;
             _anonymous = fromUser.Anonymous.HasValue && fromUser.Anonymous.Value;
-            _privateAttributeNames = fromUser.PrivateAttributeNames == null ? null :
+            _privateAttributeNames = fromUser.PrivateAttributeNames is null ? null :
                 new HashSet<string>(fromUser.PrivateAttributeNames);
-            _custom = fromUser.Custom == null ? null :
+            _custom = fromUser.Custom is null ? null :
                 new Dictionary<string, JToken>(fromUser.Custom);
         }
 
@@ -248,12 +255,18 @@ namespace LaunchDarkly.Client
                 Avatar = _avatar,
                 Email = _email,
                 Anonymous = _anonymous ? (bool?)true : null,
-                PrivateAttributeNames = _privateAttributeNames == null ? null :
+                PrivateAttributeNames = _privateAttributeNames is null ? null :
                     new HashSet<string>(_privateAttributeNames),
-                Custom = _custom == null ? new Dictionary<string, JToken>() :
+                Custom = _custom is null ? new Dictionary<string, JToken>() :
                     new Dictionary<string, JToken>(_custom)
             };
 #pragma warning restore 618
+        }
+
+        public IUserBuilder Key(string key)
+        {
+            _key = key;
+            return this;
         }
 
         public IUserBuilder SecondaryKey(string secondaryKey)
@@ -312,7 +325,7 @@ namespace LaunchDarkly.Client
 
         public IUserBuilderCanMakeAttributePrivate Custom(string name, JToken value)
         {
-            if (_custom == null)
+            if (_custom is null)
             {
                 _custom = new Dictionary<string, JToken>();
             }
@@ -347,7 +360,7 @@ namespace LaunchDarkly.Client
 
         internal IUserBuilder AddPrivateAttribute(string attrName)
         {
-            if (_privateAttributeNames == null)
+            if (_privateAttributeNames is null)
             {
                 _privateAttributeNames = new HashSet<string>();
             }
@@ -370,6 +383,11 @@ namespace LaunchDarkly.Client
         public User Build()
         {
             return _builder.Build();
+        }
+
+        public IUserBuilder Key(string key)
+        {
+            return _builder.Key(key);
         }
 
         public IUserBuilder SecondaryKey(string secondaryKey)

--- a/test/LaunchDarkly.CommonSdk.Tests/SimpleConfiguration.cs
+++ b/test/LaunchDarkly.CommonSdk.Tests/SimpleConfiguration.cs
@@ -14,8 +14,10 @@ namespace LaunchDarkly.Common.Tests
         public bool Offline { get; set; }
         public TimeSpan ReadTimeout { get; set; }
         public TimeSpan ReconnectTime { get; set;  }
-        public int EventQueueCapacity { get; set; } = 1000;
-        public TimeSpan EventQueueFrequency { get; set; }
+        public int EventCapacity { get; set; } = 1000;
+        public int EventQueueCapacity => EventCapacity;
+        public TimeSpan EventFlushInterval { get; set; }
+        public TimeSpan EventQueueFrequency => EventFlushInterval;
         public int EventSamplingInterval { get; set; }
         public bool AllAttributesPrivate { get; set; }
         public ISet<string> PrivateAttributeNames { get; set; } = new HashSet<string>();

--- a/test/LaunchDarkly.CommonSdk.Tests/UserBuilderTest.cs
+++ b/test/LaunchDarkly.CommonSdk.Tests/UserBuilderTest.cs
@@ -48,6 +48,7 @@ namespace LaunchDarkly.Common.Tests
         }
 
         public static IEnumerable<object[]> AllStringProperties => MakeParams(
+            new StringPropertyDesc("key", b => b.Key, u => u.Key),
             new StringPropertyDesc("secondary", b => b.SecondaryKey, u => u.SecondaryKey),
             new StringPropertyDesc("ip", b => b.IPAddress, u => u.IPAddress),
             new StringPropertyDesc("country", b => b.Country, u => u.Country),
@@ -92,7 +93,15 @@ namespace LaunchDarkly.Common.Tests
         public void StringPropertyIsNullByDefault(StringPropertyDesc p)
         {
             var user = User.Builder(key).Build();
-            Assert.Null(p.Getter(user));
+            var value = p.Getter(user);
+            if (p.Name == "key")
+            {
+                Assert.Equal(key, value); 
+            }
+            else
+            {
+                Assert.Null(value);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
## [2.4.0] - 2019-07-31
### Added:
- `IBaseConfiguration.EventCapacity` and `IBaseConfiguration.EventFlushInterval`.
- `UserBuilder.Key` setter.

### Deprecated:
- `IBaseConfiguration.SamplingInterval`.
- `IBaseConfiguration.EventQueueCapacity` (now a synonym for `EventCapacity`).
- `IBaseConfiguration.EventQueueFrequency` (now a synonym for `EventFlushInterval`).
