### PR TITLE
Updates outdated Docs site URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
 # Contributing to the LaunchDarkly SDK .NET Common Code
 
-LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/docs/sdk-contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
+LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/sdk/concepts/contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
 
 ## Submitting bug reports and feature requests
 
 In general, issues should be filed in the issue trackers for the [.NET server-side SDK](https://github.com/launchdarkly/dotnet-server-sdk/issues) or the [Xamarin client-side SDK](https://github.com/launchdarkly/xamarin-client-sdk/issues) rather than in this repository, unless you have a specific implementation issue regarding the code in this repository.
- 
+
 ## Submitting pull requests
- 
+
 We encourage pull requests and other contributions from the community. Before submitting pull requests, ensure that all temporary or unintended code is removed. Don't worry about adding reviewers to the pull request; the LaunchDarkly SDK team will add themselves. The SDK team will acknowledge all pull requests within two business days.
- 
+
 ## Build instructions
- 
+
 ### Prerequisites
 
 To set up your SDK build time environment, you must [download .NET Core and follow the instructions](https://dotnet.microsoft.com/download) (make sure you have 2.0 or higher).
- 
+
 ### Building
- 
+
 To install all required packages:
 
 ```
@@ -29,9 +29,9 @@ Then, to build the SDK without running any tests:
 ```
 dotnet build src/LaunchDarkly.CommonSdk -f netstandard2.0
 ```
- 
+
 ### Testing
- 
+
 To run all unit tests:
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Public Key Token: 45ef1738a929a7df
 ```
 
 ## About LaunchDarkly
- 
+
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:
     * Roll out a new feature to a subset of your users (like a group of users who opt-in to a beta tester group), gathering feedback and bug reports from real-world use cases.
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
     * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
-* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides

--- a/src/LaunchDarkly.CommonSdk/EvaluationDetail.cs
+++ b/src/LaunchDarkly.CommonSdk/EvaluationDetail.cs
@@ -126,7 +126,7 @@ namespace LaunchDarkly.Sdk
         /// </summary>
         /// <remarks>
         /// "Big segments" are a specific kind of user segments. For more information, read the LaunchDarkly
-        /// documentation about user segments: https://docs.launchdarkly.com/home/users
+        /// documentation about user segments: https://docs.launchdarkly.com/home/users/big-segments
         /// </remarks>
         public BigSegmentsStatus? BigSegmentsStatus => _bigSegmentsStatus;
 

--- a/src/LaunchDarkly.CommonSdk/User.cs
+++ b/src/LaunchDarkly.CommonSdk/User.cs
@@ -64,7 +64,7 @@ namespace LaunchDarkly.Sdk
 
         /// <summary>
         /// The secondary key for a user, which can be used in
-        /// <see href="https://docs.launchdarkly.com/docs/targeting-users#section-targeting-rules-based-on-user-attributes">feature flag targeting</see>.
+        /// <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">feature flag targeting</see>.
         /// </summary>
         /// <remarks>
         /// The use of the secondary key in targeting is as follows: if you have chosen to bucket users by a
@@ -186,7 +186,7 @@ namespace LaunchDarkly.Sdk
             _custom = ImmutableDictionary.Create<string, LdValue>();
             _privateAttributeNames = ImmutableHashSet.Create<string>();
         }
-        
+
         /// <summary>
         /// Creates a user by specifying all properties.
         /// </summary>

--- a/src/LaunchDarkly.CommonSdk/UserAttribute.cs
+++ b/src/LaunchDarkly.CommonSdk/UserAttribute.cs
@@ -15,9 +15,9 @@ namespace LaunchDarkly.Sdk
     /// </para>
     /// <para>
     /// For a fuller description of user attributes and how they can be referenced in feature
-    /// flag rules, see the reference guides on
-    /// <a href="https://docs.launchdarkly.com/home/managing-users/user-attributes">Setting user attributes</a>
-    /// and <a href="https://docs.launchdarkly.com/home/managing-flags/targeting-users">Targeting users</a>.
+    /// flag rules, read the reference guides on
+    /// <a href="https://docs.launchdarkly.com/home/users/attributes">Setting user attributes</a>
+    /// and <a href="https://docs.launchdarkly.com/home/flags/targeting-users">Targeting users</a>.
     /// </para>
     /// </remarks>
     /// <seealso cref="User"/>

--- a/src/LaunchDarkly.CommonSdk/UserBuilder.cs
+++ b/src/LaunchDarkly.CommonSdk/UserBuilder.cs
@@ -44,7 +44,7 @@ namespace LaunchDarkly.Sdk
         /// Sets the secondary key for a user.
         /// </summary>
         /// <remarks>
-        /// This affects <see href="https://docs.launchdarkly.com/docs/targeting-users#section-targeting-rules-based-on-user-attributes">feature flag targeting</see>
+        /// This affects <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">feature flag targeting</see>
         /// as follows: if you have chosen to bucket users by a specific attribute, the secondary key (if set)
         /// is used to further distinguish between users who are otherwise identical according to that attribute.
         /// </remarks>
@@ -134,13 +134,13 @@ namespace LaunchDarkly.Sdk
         /// <param name="anonymous">true if the user is anonymous</param>
         /// <returns>the same builder</returns>
         IUserBuilder AnonymousOptional(bool? anonymous);
-        
+
         /// <summary>
         /// Adds a custom attribute whose value is a JSON value of any kind.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// When set to one of the <a href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+        /// When set to one of the <a href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">built-in
         /// user attribute keys</a>, this custom attribute will be ignored.
         /// </para>
         /// </remarks>
@@ -159,7 +159,7 @@ namespace LaunchDarkly.Sdk
         /// Adds a custom attribute with a boolean value.
         /// </summary>
         /// <remarks>
-        /// When set to one of the <see href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+        /// When set to one of the <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">built-in
         /// user attribute keys</see>, this custom attribute will be ignored.
         /// </remarks>
         /// <param name="name">the key for the custom attribute</param>
@@ -171,7 +171,7 @@ namespace LaunchDarkly.Sdk
         /// Adds a custom attribute with a string value.
         /// </summary>
         /// <remarks>
-        /// When set to one of the <see href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+        /// When set to one of the <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">built-in
         /// user attribute keys</see>, this custom attribute will be ignored.
         /// </remarks>
         /// <param name="name">the key for the custom attribute</param>
@@ -183,7 +183,7 @@ namespace LaunchDarkly.Sdk
         /// Adds a custom attribute with an integer value.
         /// </summary>
         /// <remarks>
-        /// When set to one of the <see href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+        /// When set to one of the <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">built-in
         /// user attribute keys</see>, this custom attribute will be ignored.
         /// </remarks>
         /// <param name="name">the key for the custom attribute</param>
@@ -195,7 +195,7 @@ namespace LaunchDarkly.Sdk
         /// Adds a custom attribute with a floating-point value.
         /// </summary>
         /// <remarks>
-        /// When set to one of the <see href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+        /// When set to one of the <see href="https://docs.launchdarkly.com/home/flags/targeting-users#targeting-rules-based-on-user-attributes">built-in
         /// user attribute keys</see>, this custom attribute will be ignored.
         /// </remarks>
         /// <param name="name">the key for the custom attribute</param>
@@ -317,43 +317,43 @@ namespace LaunchDarkly.Sdk
             _ipAddress = ipAddress;
             return CanMakeAttributePrivate("ip");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Country(string country)
         {
             _country = country;
             return CanMakeAttributePrivate("country");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate FirstName(string firstName)
         {
             _firstName = firstName;
             return CanMakeAttributePrivate("firstName");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate LastName(string lastName)
         {
             _lastName = lastName;
             return CanMakeAttributePrivate("lastName");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Name(string name)
         {
             _name = name;
             return CanMakeAttributePrivate("name");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Avatar(string avatar)
         {
             _avatar = avatar;
             return CanMakeAttributePrivate("avatar");
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Email(string email)
         {
             _email = email;
             return CanMakeAttributePrivate("email");
         }
-        
+
         public IUserBuilder Anonymous(bool anonymous)
         {
             _anonymous = anonymous;
@@ -375,22 +375,22 @@ namespace LaunchDarkly.Sdk
             _custom[name] = value;
             return CanMakeAttributePrivate(name);
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Custom(string name, bool value)
         {
             return Custom(name, LdValue.Of(value));
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Custom(string name, string value)
         {
             return Custom(name, LdValue.Of(value));
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Custom(string name, int value)
         {
             return Custom(name, LdValue.Of(value));
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Custom(string name, float value)
         {
             return Custom(name, LdValue.Of(value));
@@ -492,7 +492,7 @@ namespace LaunchDarkly.Sdk
         {
             return _builder.Custom(name, value);
         }
-        
+
         public IUserBuilderCanMakeAttributePrivate Custom(string name, bool value)
         {
             return _builder.Custom(name, value);


### PR DESCRIPTION
**Requirements**

- [ n/a ] I have added test coverage for new or changed functionality
- [ X ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ n/a ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Updated old URLs linking to the old docs site to current URLs for the current docs site.

**Describe alternatives you've considered**

N/A

**Additional context**

Some docs site URLs changed in 2020 when we changed hosting platforms and there have been IA changes since.
Atom's linter deleted and re-added several blank lines but I'm not sure why. 