### PR TITLE
prepare 6.0.1 release

### DIFF
--- a/src/LaunchDarkly.CommonSdk/Context.cs
+++ b/src/LaunchDarkly.CommonSdk/Context.cs
@@ -622,7 +622,7 @@ namespace LaunchDarkly.Sdk
                 Kind = ContextKind.Multi;
                 _multiContexts = contexts.OrderBy(c => c.Kind.Value).ToImmutableList();
                 var buildKey = new StringBuilder();
-                foreach (var c in contexts)
+                foreach (var c in _multiContexts)
                 {
                     if (buildKey.Length != 0)
                     {

--- a/test/LaunchDarkly.CommonSdk.Tests/ContextTest.cs
+++ b/test/LaunchDarkly.CommonSdk.Tests/ContextTest.cs
@@ -100,9 +100,15 @@ namespace LaunchDarkly.Sdk
             Assert.Equal("abc:d", Context.New("abc:d").FullyQualifiedKey);
             Assert.Equal("kind1:key1", Context.New(kind1, "key1").FullyQualifiedKey);
             Assert.Equal("kind1:my%3Akey%25x/y", Context.New(kind1, "my:key%x/y").FullyQualifiedKey);
+
             Assert.Equal("kind1:key1:kind2:key%3A2", Context.NewMulti(
                 Context.New(kind1, "key1"), Context.New(kind2, "key:2")
                 ).FullyQualifiedKey);
+
+            // Key should be the same regardless of context order.
+            Assert.Equal("kind1:key1:kind2:key%3A2", Context.NewMulti(
+                Context.New(kind2, "key:2"), Context.New(kind1, "key1")
+            ).FullyQualifiedKey);
         }
 
         [Fact]


### PR DESCRIPTION
## [6.0.1] - 2023-04-04
### Fixed:
- Fixed an issue with generating the `FullyQualifiedKey`. The key generation was not sorted by the kind, so the key was not stable depending on the order of the context construction. This also affected the generation of the secure mode hash for mulit-contexts.